### PR TITLE
SAL-497 Fix FTE year picker to show current year dynamically

### DIFF
--- a/src/pages/FTE_Employee_View.page
+++ b/src/pages/FTE_Employee_View.page
@@ -138,6 +138,18 @@
             setExportyearData(YearData);
         }
 
+        $j(document).ready(function() {
+            var sel = document.getElementById('YearList');
+            if (!sel) return;
+            var cur = new Date().getFullYear();
+            for (var y = cur + 2; y >= cur - 1; y--) {
+                var opt = document.createElement('option');
+                opt.value = y; opt.text = y;
+                if (y === cur) opt.selected = true;
+                sel.appendChild(opt);
+            }
+        });
+
         function loadModalData(month, contractId) {
             if (contractId == "") {
                 loadEmployeeMonth(month);
@@ -391,12 +403,7 @@
                     </div>
                     <div style="float:left">
                         <label for="YearList">Select a Year : </label>
-                        <select name="YearList" id="YearList">
-                            <option value="2025">2025</option>
-                            <option value="2024">2024</option>
-                            <option value="2023" selected="selected">2023</option>
-                            <option value="2022">2022</option>
-                        </select>
+                        <select name="YearList" id="YearList"></select>
                     </div>
                   <!--   <div class="fteFilters">
                             <apex:outputLabel value="Select a year :" for="fteYearSelect" />


### PR DESCRIPTION
Replace hardcoded year options (2022-2025) in Export Time Cards dialog with a jQuery document-ready snippet that generates currentYear-1 through currentYear+2, defaulting to the current year.

[SAL-497 ](https://dimagi.atlassian.net/jira/software/c/projects/SAL/boards/119?selectedIssue=SAL-497 )