### PR TITLE
SAL-499 Revert DOB, Citizenship, Gender to editable in RED Form

### DIFF
--- a/src/classes/EmployeeFileController.cls
+++ b/src/classes/EmployeeFileController.cls
@@ -114,12 +114,5 @@ public String zipCodeUI {
     public void setRedForm(Record_of_Emergency_Data_Form__c redForm) {
         this.redForm = redForm;
     }
-    public String getFormattedDOB() {
-    if (redForm != null && redForm.DOB__c != null) {
-        return redForm.DOB__c.format();
-    }
-    return '';
-}
-
 
 }

--- a/src/components/RedFormComponent.component
+++ b/src/components/RedFormComponent.component
@@ -23,13 +23,9 @@
             <apex:outputText value="{!redForm.Employee_First_Name__c}"/>
             <apex:outputText value="{!redForm.Employee_Last_Name__c}"/>
             <apex:outputText value="{!redForm.Employee_Middle_Name__c}"/>
-            <!-- <apex:outputText onclick="setYear(50, 0)" value="{!redForm.DOB__c}"/> -->
-            <apex:pageBlockSectionItem >
-                <apex:outputLabel value="Date of Birth"/>
-                <apex:outputText value="{!formattedDOB}" />
-            </apex:pageBlockSectionItem>
-            <apex:outputText value="{!redForm.Citizenship__c}" />
-            <apex:outputText value="{!redForm.Gender__c}" />
+            <apex:inputField onclick="setYear(50, 0)" value="{!redForm.DOB__c}"/>
+            <apex:inputField value="{!redForm.Citizenship__c}" />
+            <apex:inputField value="{!redForm.Gender__c}" />
             <apex:outputText value="{!redForm.Current_Address_City__c}" />
             <apex:inputField value="{!redForm.Personal_Phone_Number__c}" />
             <apex:outputText value="{!redForm.Current_Address_Street__c}" />
@@ -47,7 +43,7 @@
         <apex:pageBlockSection columns="1">
             <apex:outputText escape="false"
                              style="font-weight:bold; font-style:italic;">
-                If you want to change any of the personal details above (other than phone/passport details), please reach out to POps following the instructions
+                If you want to change your name or address details above, please reach out to POps following the instructions
                 <a target="_blank"
                    href="https://dimagi.atlassian.net/wiki/spaces/internal/pages/2146007895/Change+of+Address+Personal+Details">
                     here.


### PR DESCRIPTION
Partially reverts SAL_467: DOB, Citizenship, and Gender are restored to apex:inputField (manual entry). Name and address fields remain read-only. Updated POps message to reflect that only name/address changes require POps. Removed unused getFormattedDOB() helper from EmployeeFileController.

Relates to https://dimagi.atlassian.net/jira/software/c/projects/SAL/boards/119?selectedIssue=SAL-499