### PR TITLE
Sal 511 kpi updates

### DIFF
--- a/src/classes/ArchiveLeadController.cls
+++ b/src/classes/ArchiveLeadController.cls
@@ -1,0 +1,14 @@
+public with sharing class ArchiveLeadController {
+
+    @AuraEnabled
+    public static void archiveLead(Id leadId, String archiveReason, String dispositionNotes) {
+        Lead currentLead = [SELECT Id, Status FROM Lead WHERE Id = :leadId LIMIT 1];
+
+        Lead leadUpdate = new Lead(Id = leadId);
+        leadUpdate.Status = 'Archived - Not Interested';
+        leadUpdate.Archive_Reason__c = archiveReason;
+        leadUpdate.Disposition_Notes__c = dispositionNotes;
+        leadUpdate.Lead_Stage_at_Exit__c = currentLead.Status;
+        update leadUpdate;
+    }
+}

--- a/src/classes/ArchiveLeadController.cls
+++ b/src/classes/ArchiveLeadController.cls
@@ -2,13 +2,20 @@ public with sharing class ArchiveLeadController {
 
     @AuraEnabled
     public static void archiveLead(Id leadId, String archiveReason, String dispositionNotes) {
-        Lead currentLead = [SELECT Id, Status FROM Lead WHERE Id = :leadId LIMIT 1];
+        List<Lead> leads = [SELECT Id, Status FROM Lead WHERE Id = :leadId LIMIT 1];
+        if (leads.isEmpty()) {
+            throw new AuraHandledException('Lead not found or has been deleted.');
+        }
 
         Lead leadUpdate = new Lead(Id = leadId);
         leadUpdate.Status = 'Archived - Not Interested';
         leadUpdate.Archive_Reason__c = archiveReason;
         leadUpdate.Disposition_Notes__c = dispositionNotes;
-        leadUpdate.Lead_Stage_at_Exit__c = currentLead.Status;
-        update leadUpdate;
+        leadUpdate.Lead_Stage_at_Exit__c = leads[0].Status;
+        try {
+            update leadUpdate;
+        } catch (DmlException e) {
+            throw new AuraHandledException(e.getDmlMessage(0));
+        }
     }
 }

--- a/src/classes/ArchiveLeadController.cls-meta.xml
+++ b/src/classes/ArchiveLeadController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -86,6 +86,9 @@ public with sharing class ConvertLeadController {
                 opp.Renewal_expected__c = true;
                 opp.Opportunity_Owner_Division__c = currentLead.Opportunity_Owner_Division__c;
                 opp.Opportunity_Owner_Sub_Division__c = currentLead.Opportunity_Owner_Sub_Division__c;
+                opp.Expected_Buffer__c = 0;
+                opp.Execution_Owner_Division__c = currentLead.Opportunity_Owner_Division__c;
+                opp.Execution_Owner_Practice__c = currentLead.Opportunity_Owner_Sub_Division__c;
 
                 List<Business_Unit__c> bus = [SELECT Id FROM Business_Unit__c WHERE Name = 'Inc' LIMIT 1];
                 if (!bus.isEmpty()) {

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -14,8 +14,12 @@ public with sharing class ConvertLeadController {
         Boolean gspPrimaryContact
     ) {
         // Capture current status before we change anything — this becomes Lead_Stage_at_Exit__c
-        Lead currentLead = [SELECT Id, Status, Company, Opportunity_Owner_Division__c, Opportunity_Owner_Sub_Division__c
+        List<Lead> leads = [SELECT Id, Status, Company, Opportunity_Owner_Division__c, Opportunity_Owner_Sub_Division__c
                             FROM Lead WHERE Id = :leadId LIMIT 1];
+        if (leads.isEmpty()) {
+            throw new AuraHandledException('Lead not found or has been deleted.');
+        }
+        Lead currentLead = leads[0];
 
         // Write context fields + stage at exit before calling convertLead, so the data is
         // preserved even if conversion fails and the rep needs to retry.

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -90,6 +90,7 @@ public with sharing class ConvertLeadController {
                 opp.Expected_Buffer__c = 0;
                 opp.Execution_Owner_Division__c = currentLead.Opportunity_Owner_Division__c;
                 opp.Execution_Owner_Practice__c = currentLead.Opportunity_Owner_Sub_Division__c;
+                opp.Source_Lead__c = leadId;
 
                 List<Business_Unit__c> bus = [SELECT Id FROM Business_Unit__c WHERE Name = 'Inc' LIMIT 1];
                 if (!bus.isEmpty()) {

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -1,4 +1,29 @@
-public with sharing class ConvertLeadController {
+@RestResource(urlMapping='/convert-lead/*')
+global with sharing class ConvertLeadController {
+
+    @HttpPost
+    global static ConvertResult convertLeadRest() {
+        Map<String, Object> body = (Map<String, Object>) JSON.deserializeUntyped(
+            RestContext.request.requestBody.toString()
+        );
+
+        Id leadId                  = body.containsKey('leadId')             ? (Id)     body.get('leadId')             : null;
+        String conversionOutcome   = body.containsKey('conversionOutcome')  ? (String) body.get('conversionOutcome')  : null;
+        String dispositionNotes    = body.containsKey('dispositionNotes')   ? (String) body.get('dispositionNotes')   : null;
+        String reEngagementPathway = body.containsKey('reEngagementPathway')? (String) body.get('reEngagementPathway'): null;
+        Date reEngageDate          = body.containsKey('reEngageDate') && body.get('reEngageDate') != null
+                                        ? Date.valueOf((String) body.get('reEngageDate'))
+                                        : null;
+        Id existingAccountId       = body.containsKey('existingAccountId')  ? (Id)      body.get('existingAccountId') : null;
+        Id existingContactId       = body.containsKey('existingContactId')  ? (Id)      body.get('existingContactId') : null;
+        String opportunityName     = body.containsKey('opportunityName')    ? (String)  body.get('opportunityName')   : null;
+        String contactStatus       = body.containsKey('contactStatus')      ? (String)  body.get('contactStatus')     : null;
+        Boolean gspPrimaryContact  = body.containsKey('gspPrimaryContact')  ? (Boolean) body.get('gspPrimaryContact') : false;
+
+        return convertLead(leadId, conversionOutcome, dispositionNotes, reEngagementPathway,
+                           reEngageDate, existingAccountId, existingContactId,
+                           opportunityName, contactStatus, gspPrimaryContact);
+    }
 
     @AuraEnabled
     public static ConvertResult convertLead(
@@ -167,7 +192,7 @@ public with sharing class ConvertLeadController {
         return m;
     }
 
-    public class SuggestedMatches {
+    global class SuggestedMatches {
         @AuraEnabled public Id accountId;
         @AuraEnabled public String accountName;
         @AuraEnabled public Id contactId;
@@ -177,7 +202,7 @@ public with sharing class ConvertLeadController {
         @AuraEnabled public Boolean contactGspPrimaryContact;
     }
 
-    public class ConvertResult {
+    global class ConvertResult {
         @AuraEnabled public Boolean success;
         @AuraEnabled public String errorMessage;
         @AuraEnabled public Id accountId;

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -62,7 +62,7 @@ public with sharing class ConvertLeadController {
             if (cr.contactId != null) {
                 Contact c = [SELECT Id, Lead_Cycle_Count__c FROM Contact WHERE Id = :cr.contactId LIMIT 1];
                 c.Status__c = String.isNotBlank(contactStatus) ? contactStatus : '1- Working - Active Opp Development';
-                c.GSP_Primary_Contact__c = gspPrimaryContact == true;
+                c.GSP_Primary_Contact__c = gspPrimaryContact;
                 c.Last_Lead_Outcome__c = conversionOutcome;
                 c.Last_Lead_Context__c = dispositionNotes;
                 c.Follow_up_Date__c = reEngageDate;

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -1,0 +1,168 @@
+public with sharing class ConvertLeadController {
+
+    @AuraEnabled
+    public static ConvertResult convertLead(
+        Id leadId,
+        String conversionOutcome,
+        String dispositionNotes,
+        String reEngagementPathway,
+        Date reEngageDate,
+        Id existingAccountId,
+        Id existingContactId,
+        String opportunityName
+    ) {
+        // Capture current status before we change anything — this becomes Lead_Stage_at_Exit__c
+        Lead currentLead = [SELECT Id, Status, Company, Opportunity_Owner_Division__c, Opportunity_Owner_Sub_Division__c
+                            FROM Lead WHERE Id = :leadId LIMIT 1];
+
+        // Write context fields + stage at exit before calling convertLead, so the data is
+        // preserved even if conversion fails and the rep needs to retry.
+        Lead leadUpdate = new Lead(Id = leadId);
+        leadUpdate.Conversion_Outcome__c = conversionOutcome;
+        leadUpdate.Disposition_Notes__c = dispositionNotes;
+        leadUpdate.Re_engagement_Pathway__c = reEngagementPathway;
+        leadUpdate.Re_engage_Date__c = reEngageDate;
+        leadUpdate.Lead_Stage_at_Exit__c = currentLead.Status;
+        update leadUpdate;
+
+        Boolean createOpportunity = conversionOutcome == 'With Opportunity';
+
+        Database.LeadConvert lc = new Database.LeadConvert();
+        lc.setLeadId(leadId);
+        lc.setConvertedStatus('Converted');
+        lc.setDoNotCreateOpportunity(!createOpportunity);
+
+        if (existingAccountId != null) {
+            lc.setAccountId(existingAccountId);
+        }
+        if (existingContactId != null) {
+            lc.setContactId(existingContactId);
+        }
+        if (createOpportunity && String.isNotBlank(opportunityName)) {
+            lc.setOpportunityName(opportunityName);
+        }
+
+        ConvertResult cr = new ConvertResult();
+        try {
+            Database.LeadConvertResult result = Database.convertLead(lc);
+
+            if (!result.isSuccess()) {
+                cr.success = false;
+                cr.errorMessage = result.getErrors()[0].getMessage();
+                return cr;
+            }
+
+            cr.accountId = result.getAccountId();
+            cr.contactId = result.getContactId();
+            cr.opportunityId = result.getOpportunityId();
+
+            // Update Contact: status (existing behavior) + lead context fields
+            if (cr.contactId != null) {
+                Contact c = [SELECT Id, Lead_Cycle_Count__c FROM Contact WHERE Id = :cr.contactId LIMIT 1];
+                c.Status__c = '1- Working - Active Opp Development';
+                c.Last_Lead_Outcome__c = conversionOutcome;
+                c.Last_Lead_Context__c = dispositionNotes;
+                c.Last_Lead_Re_engage_Date__c = reEngageDate;
+                c.Last_Lead_Re_engagement_Pathway__c = reEngagementPathway;
+                c.Last_Lead_Date__c = Date.today();
+                c.Lead_Cycle_Count__c = (c.Lead_Cycle_Count__c == null ? 0 : c.Lead_Cycle_Count__c) + 1;
+                update c;
+            }
+
+            // Set Opportunity defaults — mirrors the existing LeadConversionController behavior
+            if (cr.opportunityId != null) {
+                Opportunity opp = new Opportunity(Id = cr.opportunityId);
+                opp.StageName = 'Stage 3 - Prospect';
+                opp.Probability = 20;
+                opp.of_Execution_budget_for_GS__c = 0;
+                opp.Channel_Response__c = 'Inside Sales';
+                opp.Implementation_Type__c = 'Self Service';
+                opp.Opportunity_Source__c = 'Inbound';
+                opp.Duration_months__c = 12;
+                opp.CloseDate = Date.today().addMonths(2).toStartOfMonth().addDays(-1);
+                opp.Renewal_expected__c = true;
+                opp.Opportunity_Owner_Division__c = currentLead.Opportunity_Owner_Division__c;
+                opp.Opportunity_Owner_Sub_Division__c = currentLead.Opportunity_Owner_Sub_Division__c;
+
+                List<Business_Unit__c> bus = [SELECT Id FROM Business_Unit__c WHERE Name = 'Inc' LIMIT 1];
+                if (!bus.isEmpty()) {
+                    opp.Opportunity_Owning_Entity__c = bus[0].Id;
+                }
+                update opp;
+            }
+
+            cr.success = true;
+        } catch (DmlException e) {
+            cr.success = false;
+            cr.errorMessage = e.getDmlMessage(0);
+        } catch (Exception e) {
+            cr.success = false;
+            cr.errorMessage = e.getMessage();
+        }
+
+        return cr;
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static List<Account> searchAccounts(String searchTerm) {
+        String s = '%' + String.escapeSingleQuotes(searchTerm) + '%';
+        return [SELECT Id, Name FROM Account WHERE Name LIKE :s ORDER BY Name LIMIT 10];
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static List<Contact> searchContacts(String searchTerm) {
+        String s = '%' + String.escapeSingleQuotes(searchTerm) + '%';
+        return [SELECT Id, Name, Email, Account.Name
+                FROM Contact WHERE Name LIKE :s OR Email LIKE :s ORDER BY Name LIMIT 10];
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static Lead getLeadDetails(Id leadId) {
+        List<Lead> leads = [SELECT Id, FirstName, LastName, Name, Company, Email, Status FROM Lead WHERE Id = :leadId LIMIT 1];
+        return leads.isEmpty() ? null : leads[0];
+    }
+
+    @AuraEnabled
+    public static SuggestedMatches getSuggestedMatches(Id leadId) {
+        SuggestedMatches m = new SuggestedMatches();
+        List<Lead> leads = [SELECT account_name__c, Company, Email FROM Lead WHERE Id = :leadId LIMIT 1];
+        if (leads.isEmpty()) return m;
+        Lead lead = leads[0];
+        if (lead.account_name__c != null) {
+            List<Account> accts = [SELECT Id, Name FROM Account WHERE Id = :lead.account_name__c LIMIT 1];
+            if (!accts.isEmpty()) {
+                m.accountId = accts[0].Id;
+                m.accountName = accts[0].Name;
+            }
+        } else if (String.isNotBlank(lead.Company)) {
+            List<Account> accts = [SELECT Id, Name FROM Account WHERE Name = :lead.Company LIMIT 1];
+            if (!accts.isEmpty()) {
+                m.accountId = accts[0].Id;
+                m.accountName = accts[0].Name;
+            }
+        }
+        if (String.isNotBlank(lead.Email)) {
+            List<Contact> cons = [SELECT Id, Name FROM Contact WHERE Email = :lead.Email LIMIT 1];
+            if (!cons.isEmpty()) {
+                m.contactId = cons[0].Id;
+                m.contactName = cons[0].Name;
+            }
+        }
+        return m;
+    }
+
+    public class SuggestedMatches {
+        @AuraEnabled public Id accountId;
+        @AuraEnabled public String accountName;
+        @AuraEnabled public Id contactId;
+        @AuraEnabled public String contactName;
+    }
+
+    public class ConvertResult {
+        @AuraEnabled public Boolean success;
+        @AuraEnabled public String errorMessage;
+        @AuraEnabled public Id accountId;
+        @AuraEnabled public Id contactId;
+        @AuraEnabled public Id opportunityId;
+    }
+}

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -75,7 +75,7 @@ public with sharing class ConvertLeadController {
             // Set Opportunity defaults — mirrors the existing LeadConversionController behavior
             if (cr.opportunityId != null) {
                 Opportunity opp = new Opportunity(Id = cr.opportunityId);
-                opp.StageName = 'Stage 3 - Prospect';
+                opp.StageName = 'Stage 4 - Proposal Development';
                 opp.Probability = 20;
                 opp.of_Execution_budget_for_GS__c = 0;
                 opp.Channel_Response__c = 'Inside Sales';

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -1,6 +1,24 @@
 @RestResource(urlMapping='/convert-lead/*')
 global with sharing class ConvertLeadController {
 
+    @HttpGet
+    global static SuggestedMatches getSuggestedMatchesRest() {
+        Id leadId;
+        try {
+            leadId = (Id) RestContext.request.params.get('leadId');
+        } catch (Exception e) {
+            return new SuggestedMatches();
+        }
+        SuggestedMatches m = new SuggestedMatches();
+        if (leadId == null) return m;
+        try {
+            m = getSuggestedMatches(leadId);
+        } catch (Exception e) {
+            // return empty matches rather than HTTP 500
+        }
+        return m;
+    }
+
     @HttpPost
     global static ConvertResult convertLeadRest() {
         Map<String, Object> body = (Map<String, Object>) JSON.deserializeUntyped(
@@ -20,9 +38,25 @@ global with sharing class ConvertLeadController {
         String contactStatus       = body.containsKey('contactStatus')      ? (String)  body.get('contactStatus')     : null;
         Boolean gspPrimaryContact  = body.containsKey('gspPrimaryContact')  ? (Boolean) body.get('gspPrimaryContact') : false;
 
-        return convertLead(leadId, conversionOutcome, dispositionNotes, reEngagementPathway,
-                           reEngageDate, existingAccountId, existingContactId,
-                           opportunityName, contactStatus, gspPrimaryContact);
+        ConvertResult cr = new ConvertResult();
+        try {
+            List<Lead> leads = [SELECT Id, Status, Company,
+                                       Opportunity_Owner_Division__c,
+                                       Opportunity_Owner_Sub_Division__c
+                                FROM Lead WHERE Id = :leadId LIMIT 1];
+            if (leads.isEmpty()) {
+                cr.success = false;
+                cr.errorMessage = 'Lead not found or has been deleted.';
+                return cr;
+            }
+            cr = doConvertLead(leads[0], conversionOutcome, dispositionNotes, reEngagementPathway,
+                               reEngageDate, existingAccountId, existingContactId,
+                               opportunityName, contactStatus, gspPrimaryContact);
+        } catch (Exception e) {
+            cr.success = false;
+            cr.errorMessage = e.getMessage();
+        }
+        return cr;
     }
 
     @AuraEnabled
@@ -38,17 +72,33 @@ global with sharing class ConvertLeadController {
         String contactStatus,
         Boolean gspPrimaryContact
     ) {
-        // Capture current status before we change anything — this becomes Lead_Stage_at_Exit__c
-        List<Lead> leads = [SELECT Id, Status, Company, Opportunity_Owner_Division__c, Opportunity_Owner_Sub_Division__c
+        List<Lead> leads = [SELECT Id, Status, Company,
+                                   Opportunity_Owner_Division__c,
+                                   Opportunity_Owner_Sub_Division__c
                             FROM Lead WHERE Id = :leadId LIMIT 1];
         if (leads.isEmpty()) {
             throw new AuraHandledException('Lead not found or has been deleted.');
         }
-        Lead currentLead = leads[0];
+        return doConvertLead(leads[0], conversionOutcome, dispositionNotes, reEngagementPathway,
+                             reEngageDate, existingAccountId, existingContactId,
+                             opportunityName, contactStatus, gspPrimaryContact);
+    }
 
+    private static ConvertResult doConvertLead(
+        Lead currentLead,
+        String conversionOutcome,
+        String dispositionNotes,
+        String reEngagementPathway,
+        Date reEngageDate,
+        Id existingAccountId,
+        Id existingContactId,
+        String opportunityName,
+        String contactStatus,
+        Boolean gspPrimaryContact
+    ) {
         // Write context fields + stage at exit before calling convertLead, so the data is
         // preserved even if conversion fails and the rep needs to retry.
-        Lead leadUpdate = new Lead(Id = leadId);
+        Lead leadUpdate = new Lead(Id = currentLead.Id);
         leadUpdate.Conversion_Outcome__c = conversionOutcome;
         leadUpdate.Disposition_Notes__c = dispositionNotes;
         leadUpdate.Re_engagement_Pathway__c = reEngagementPathway;
@@ -59,7 +109,7 @@ global with sharing class ConvertLeadController {
         Boolean createOpportunity = conversionOutcome == 'With Opportunity';
 
         Database.LeadConvert lc = new Database.LeadConvert();
-        lc.setLeadId(leadId);
+        lc.setLeadId(currentLead.Id);
         lc.setConvertedStatus('Converted');
         lc.setDoNotCreateOpportunity(!createOpportunity);
 
@@ -91,7 +141,7 @@ global with sharing class ConvertLeadController {
             if (cr.contactId != null) {
                 Contact c = [SELECT Id, Lead_Cycle_Count__c, Lead__c FROM Contact WHERE Id = :cr.contactId LIMIT 1];
                 c.Status__c = String.isNotBlank(contactStatus) ? contactStatus : '1- Working - Active Opp Development';
-                if (c.Lead__c == null) c.Lead__c = leadId;
+                if (c.Lead__c == null) c.Lead__c = currentLead.Id;
                 c.GSP_Primary_Contact__c = gspPrimaryContact;
                 c.Last_Lead_Outcome__c = conversionOutcome;
                 c.Last_Lead_Context__c = dispositionNotes;
@@ -119,7 +169,7 @@ global with sharing class ConvertLeadController {
                 opp.Expected_Buffer__c = 0;
                 opp.Execution_Owner_Division__c = currentLead.Opportunity_Owner_Division__c;
                 opp.Execution_Owner_Practice__c = currentLead.Opportunity_Owner_Sub_Division__c;
-                opp.Source_Lead__c = leadId;
+                opp.Source_Lead__c = currentLead.Id;
 
                 List<Business_Unit__c> bus = [SELECT Id FROM Business_Unit__c WHERE Name = 'Inc' LIMIT 1];
                 if (!bus.isEmpty()) {

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -9,7 +9,9 @@ public with sharing class ConvertLeadController {
         Date reEngageDate,
         Id existingAccountId,
         Id existingContactId,
-        String opportunityName
+        String opportunityName,
+        String contactStatus,
+        Boolean gspPrimaryContact
     ) {
         // Capture current status before we change anything — this becomes Lead_Stage_at_Exit__c
         Lead currentLead = [SELECT Id, Status, Company, Opportunity_Owner_Division__c, Opportunity_Owner_Sub_Division__c
@@ -59,10 +61,11 @@ public with sharing class ConvertLeadController {
             // Update Contact: status (existing behavior) + lead context fields
             if (cr.contactId != null) {
                 Contact c = [SELECT Id, Lead_Cycle_Count__c FROM Contact WHERE Id = :cr.contactId LIMIT 1];
-                c.Status__c = '1- Working - Active Opp Development';
+                c.Status__c = String.isNotBlank(contactStatus) ? contactStatus : '1- Working - Active Opp Development';
+                c.GSP_Primary_Contact__c = gspPrimaryContact == true;
                 c.Last_Lead_Outcome__c = conversionOutcome;
                 c.Last_Lead_Context__c = dispositionNotes;
-                c.Last_Lead_Re_engage_Date__c = reEngageDate;
+                c.Follow_up_Date__c = reEngageDate;
                 c.Last_Lead_Re_engagement_Pathway__c = reEngagementPathway;
                 c.Last_Lead_Date__c = Date.today();
                 c.Lead_Cycle_Count__c = (c.Lead_Cycle_Count__c == null ? 0 : c.Lead_Cycle_Count__c) + 1;
@@ -112,7 +115,7 @@ public with sharing class ConvertLeadController {
     @AuraEnabled(cacheable=true)
     public static List<Contact> searchContacts(String searchTerm) {
         String s = '%' + String.escapeSingleQuotes(searchTerm) + '%';
-        return [SELECT Id, Name, Email, Account.Name
+        return [SELECT Id, Name, Email, Account.Name, Status__c, GSP_Primary_Contact__c
                 FROM Contact WHERE Name LIKE :s OR Email LIKE :s ORDER BY Name LIMIT 10];
     }
 
@@ -142,10 +145,14 @@ public with sharing class ConvertLeadController {
             }
         }
         if (String.isNotBlank(lead.Email)) {
-            List<Contact> cons = [SELECT Id, Name FROM Contact WHERE Email = :lead.Email LIMIT 1];
+            List<Contact> cons = [SELECT Id, Name, Follow_up_Date__c, Status__c, GSP_Primary_Contact__c
+                                  FROM Contact WHERE Email = :lead.Email LIMIT 1];
             if (!cons.isEmpty()) {
                 m.contactId = cons[0].Id;
                 m.contactName = cons[0].Name;
+                m.contactFollowUpDate = cons[0].Follow_up_Date__c;
+                m.contactStatus = cons[0].Status__c;
+                m.contactGspPrimaryContact = cons[0].GSP_Primary_Contact__c;
             }
         }
         return m;
@@ -156,6 +163,9 @@ public with sharing class ConvertLeadController {
         @AuraEnabled public String accountName;
         @AuraEnabled public Id contactId;
         @AuraEnabled public String contactName;
+        @AuraEnabled public Date contactFollowUpDate;
+        @AuraEnabled public String contactStatus;
+        @AuraEnabled public Boolean contactGspPrimaryContact;
     }
 
     public class ConvertResult {

--- a/src/classes/ConvertLeadController.cls
+++ b/src/classes/ConvertLeadController.cls
@@ -60,8 +60,9 @@ public with sharing class ConvertLeadController {
 
             // Update Contact: status (existing behavior) + lead context fields
             if (cr.contactId != null) {
-                Contact c = [SELECT Id, Lead_Cycle_Count__c FROM Contact WHERE Id = :cr.contactId LIMIT 1];
+                Contact c = [SELECT Id, Lead_Cycle_Count__c, Lead__c FROM Contact WHERE Id = :cr.contactId LIMIT 1];
                 c.Status__c = String.isNotBlank(contactStatus) ? contactStatus : '1- Working - Active Opp Development';
+                if (c.Lead__c == null) c.Lead__c = leadId;
                 c.GSP_Primary_Contact__c = gspPrimaryContact;
                 c.Last_Lead_Outcome__c = conversionOutcome;
                 c.Last_Lead_Context__c = dispositionNotes;

--- a/src/classes/ConvertLeadController.cls-meta.xml
+++ b/src/classes/ConvertLeadController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ConvertLeadControllerTest.cls
+++ b/src/classes/ConvertLeadControllerTest.cls
@@ -260,6 +260,38 @@ public class ConvertLeadControllerTest {
         System.assertEquals(null, m.contactId);
     }
 
+    @isTest
+    static void testConvertLeadRest() {
+        Lead testLead = makeTestLead('REST Test Co');
+        insert testLead;
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/convert-lead/';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(JSON.serialize(new Map<String, Object>{
+            'leadId'               => testLead.Id,
+            'conversionOutcome'    => 'With Opportunity',
+            'dispositionNotes'     => 'REST call test',
+            'reEngagementPathway'  => null,
+            'reEngageDate'         => null,
+            'existingAccountId'    => null,
+            'existingContactId'    => null,
+            'opportunityName'      => 'REST Test Co - Deal',
+            'contactStatus'        => '1- Working - Active Opp Development',
+            'gspPrimaryContact'    => false
+        }));
+        RestContext.request  = req;
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        ConvertLeadController.ConvertResult result = ConvertLeadController.convertLeadRest();
+        Test.stopTest();
+
+        System.assert(result.success, 'REST conversion failed: ' + result.errorMessage);
+        System.assertNotEquals(null, result.opportunityId, 'Opportunity should be created via REST');
+        System.assertNotEquals(null, result.contactId, 'Contact should be created via REST');
+    }
+
     // ── ArchiveLeadController ──────────────────────────────────────────────────
 
     @isTest

--- a/src/classes/ConvertLeadControllerTest.cls
+++ b/src/classes/ConvertLeadControllerTest.cls
@@ -292,6 +292,52 @@ public class ConvertLeadControllerTest {
         System.assertNotEquals(null, result.contactId, 'Contact should be created via REST');
     }
 
+    @isTest
+    static void testConvertLeadRestLeadNotFound() {
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/convert-lead/';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(JSON.serialize(new Map<String, Object>{
+            'leadId'            => '00Q000000000000AAA',
+            'conversionOutcome' => 'With Opportunity'
+        }));
+        RestContext.request  = req;
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        ConvertLeadController.ConvertResult result = ConvertLeadController.convertLeadRest();
+        Test.stopTest();
+
+        System.assertEquals(false, result.success, 'Should report failure for missing lead');
+        System.assert(String.isNotBlank(result.errorMessage), 'Should include an error message');
+    }
+
+    @isTest
+    static void testGetSuggestedMatchesRest() {
+        Account acc = new Account(Name = 'REST Suggested Corp');
+        insert acc;
+        Contact con = new Contact(FirstName = 'REST', LastName = 'Match', AccountId = acc.Id, Email = 'restmatch@suggested.com');
+        insert con;
+        Lead testLead = makeTestLead('REST Suggested Corp');
+        testLead.account_name__c = acc.Id;
+        testLead.Email = 'restmatch@suggested.com';
+        insert testLead;
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/convert-lead/';
+        req.httpMethod = 'GET';
+        req.params.put('leadId', testLead.Id);
+        RestContext.request  = req;
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        ConvertLeadController.SuggestedMatches m = ConvertLeadController.getSuggestedMatchesRest();
+        Test.stopTest();
+
+        System.assertEquals(acc.Id, m.accountId, 'Should return account via REST');
+        System.assertEquals(con.Id, m.contactId, 'Should return contact via REST');
+    }
+
     // ── ArchiveLeadController ──────────────────────────────────────────────────
 
     @isTest

--- a/src/classes/ConvertLeadControllerTest.cls
+++ b/src/classes/ConvertLeadControllerTest.cls
@@ -213,6 +213,53 @@ public class ConvertLeadControllerTest {
         System.assertEquals('Detail Co', result.Company);
     }
 
+    @isTest
+    static void testGetSuggestedMatchesWithAccountNameLookup() {
+        Account acc = new Account(Name = 'Suggested Corp');
+        insert acc;
+        Contact con = new Contact(FirstName = 'Match', LastName = 'Person', AccountId = acc.Id, Email = 'match@suggested.com');
+        insert con;
+        Lead testLead = makeTestLead('Suggested Corp');
+        testLead.account_name__c = acc.Id;
+        testLead.Email = 'match@suggested.com';
+        insert testLead;
+
+        Test.startTest();
+        ConvertLeadController.SuggestedMatches m = ConvertLeadController.getSuggestedMatches(testLead.Id);
+        Test.stopTest();
+
+        System.assertEquals(acc.Id, m.accountId, 'Should match account via account_name__c lookup');
+        System.assertEquals(con.Id, m.contactId, 'Should match contact via email');
+    }
+
+    @isTest
+    static void testGetSuggestedMatchesWithCompanyName() {
+        Account acc = new Account(Name = 'CompanyMatch Corp');
+        insert acc;
+        Lead testLead = makeTestLead('CompanyMatch Corp');
+        insert testLead;
+
+        Test.startTest();
+        ConvertLeadController.SuggestedMatches m = ConvertLeadController.getSuggestedMatches(testLead.Id);
+        Test.stopTest();
+
+        System.assertEquals(acc.Id, m.accountId, 'Should match account via Company name');
+        System.assertEquals(null, m.contactId, 'No contact match expected');
+    }
+
+    @isTest
+    static void testGetSuggestedMatchesNoMatch() {
+        Lead testLead = makeTestLead('No Match Co XYZ');
+        insert testLead;
+
+        Test.startTest();
+        ConvertLeadController.SuggestedMatches m = ConvertLeadController.getSuggestedMatches(testLead.Id);
+        Test.stopTest();
+
+        System.assertEquals(null, m.accountId);
+        System.assertEquals(null, m.contactId);
+    }
+
     // ── ArchiveLeadController ──────────────────────────────────────────────────
 
     @isTest

--- a/src/classes/ConvertLeadControllerTest.cls
+++ b/src/classes/ConvertLeadControllerTest.cls
@@ -37,11 +37,13 @@ public class ConvertLeadControllerTest {
             null,
             null,
             null,
-            'OpportunityTest Co - Deal'
+            'OpportunityTest Co - Deal',
+            '1- Working - Active Opp Development',
+            false
         );
         Test.stopTest();
 
-        System.assertEquals(true, result.success, result.errorMessage);
+        System.assert(result.success, 'Conversion failed: ' + result.errorMessage);
         System.assertNotEquals(null, result.opportunityId, 'Opportunity should be created');
         System.assertNotEquals(null, result.contactId, 'Contact should be created');
 
@@ -55,14 +57,15 @@ public class ConvertLeadControllerTest {
         System.assertEquals('Stage 3 - Prospect', opp.StageName);
         System.assertEquals(20, opp.Probability);
 
-        Contact con = [SELECT Status__c, Last_Lead_Outcome__c, Last_Lead_Context__c,
-                              Last_Lead_Re_engage_Date__c, Last_Lead_Re_engagement_Pathway__c,
-                              Last_Lead_Date__c, Lead_Cycle_Count__c
+        Contact con = [SELECT Status__c, GSP_Primary_Contact__c, Last_Lead_Outcome__c,
+                              Last_Lead_Context__c, Follow_up_Date__c,
+                              Last_Lead_Re_engagement_Pathway__c, Last_Lead_Date__c, Lead_Cycle_Count__c
                        FROM Contact WHERE Id = :result.contactId];
         System.assertEquals('1- Working - Active Opp Development', con.Status__c);
+        System.assertEquals(false, con.GSP_Primary_Contact__c);
         System.assertEquals('With Opportunity', con.Last_Lead_Outcome__c);
         System.assertEquals('Great fit, moving forward.', con.Last_Lead_Context__c);
-        System.assertEquals(null, con.Last_Lead_Re_engage_Date__c);
+        System.assertEquals(null, con.Follow_up_Date__c);
         System.assertEquals(null, con.Last_Lead_Re_engagement_Pathway__c);
         System.assertEquals(Date.today(), con.Last_Lead_Date__c);
         System.assertEquals(1, con.Lead_Cycle_Count__c);
@@ -82,11 +85,13 @@ public class ConvertLeadControllerTest {
             Date.today().addMonths(3),
             null,
             null,
-            null
+            null,
+            '1- Working - Active Opp Development',
+            false
         );
         Test.stopTest();
 
-        System.assertEquals(true, result.success, result.errorMessage);
+        System.assert(result.success, 'Conversion failed: ' + result.errorMessage);
         System.assertEquals(null, result.opportunityId, 'No opportunity should be created');
         System.assertNotEquals(null, result.contactId, 'Contact should be created');
 
@@ -95,12 +100,12 @@ public class ConvertLeadControllerTest {
         System.assertEquals('Scheduled Follow-up', updatedLead.Re_engagement_Pathway__c);
         System.assertEquals(Date.today().addMonths(3), updatedLead.Re_engage_Date__c);
 
-        Contact con = [SELECT Last_Lead_Outcome__c, Last_Lead_Context__c, Last_Lead_Re_engage_Date__c,
+        Contact con = [SELECT Last_Lead_Outcome__c, Last_Lead_Context__c, Follow_up_Date__c,
                               Last_Lead_Re_engagement_Pathway__c, Last_Lead_Date__c, Lead_Cycle_Count__c
                        FROM Contact WHERE Id = :result.contactId];
         System.assertEquals('Contact Only - Passive', con.Last_Lead_Outcome__c);
         System.assertEquals('Good relationship, no immediate opportunity.', con.Last_Lead_Context__c);
-        System.assertEquals(Date.today().addMonths(3), con.Last_Lead_Re_engage_Date__c);
+        System.assertEquals(Date.today().addMonths(3), con.Follow_up_Date__c);
         System.assertEquals('Scheduled Follow-up', con.Last_Lead_Re_engagement_Pathway__c);
         System.assertEquals(Date.today(), con.Last_Lead_Date__c);
         System.assertEquals(1, con.Lead_Cycle_Count__c);
@@ -122,11 +127,13 @@ public class ConvertLeadControllerTest {
             null,
             existingAccount.Id,
             null,
-            'Existing Account Corp - Deal'
+            'Existing Account Corp - Deal',
+            '1- Working - Active Opp Development',
+            false
         );
         Test.stopTest();
 
-        System.assertEquals(true, result.success, result.errorMessage);
+        System.assert(result.success, 'Conversion failed: ' + result.errorMessage);
         System.assertEquals(existingAccount.Id, result.accountId, 'Should use the existing account');
         System.assertEquals(1, [SELECT COUNT() FROM Account WHERE Name = 'Existing Account Corp'], 'No duplicate account should be created');
     }
@@ -135,7 +142,7 @@ public class ConvertLeadControllerTest {
     static void testConvertWithExistingContact() {
         Account acc = new Account(Name = 'Contact Match Co');
         insert acc;
-        Contact existingContact = new Contact(FirstName = 'Test', LastName = 'Lead', AccountId = acc.Id, Email = 'test@example.com');
+        Contact existingContact = new Contact(FirstName = 'Test', LastName = 'Lead', AccountId = acc.Id, Email = 'existing@example.com');
         insert existingContact;
         Lead testLead = makeTestLead('Contact Match Co');
         insert testLead;
@@ -149,18 +156,21 @@ public class ConvertLeadControllerTest {
             null,
             acc.Id,
             existingContact.Id,
-            null
+            null,
+            '1- Working - Active Opp Development',
+            true
         );
         Test.stopTest();
 
-        System.assertEquals(true, result.success, result.errorMessage);
+        System.assert(result.success, 'Conversion failed: ' + result.errorMessage);
         System.assertEquals(existingContact.Id, result.contactId, 'Should use the existing contact');
 
-        Contact con = [SELECT Last_Lead_Outcome__c, Last_Lead_Date__c, Lead_Cycle_Count__c
+        Contact con = [SELECT Last_Lead_Outcome__c, Last_Lead_Date__c, Lead_Cycle_Count__c, GSP_Primary_Contact__c
                        FROM Contact WHERE Id = :result.contactId];
         System.assertEquals('Contact Only - Nurture', con.Last_Lead_Outcome__c);
         System.assertEquals(Date.today(), con.Last_Lead_Date__c);
         System.assertEquals(1, con.Lead_Cycle_Count__c);
+        System.assertEquals(true, con.GSP_Primary_Contact__c);
     }
 
     @isTest

--- a/src/classes/ConvertLeadControllerTest.cls
+++ b/src/classes/ConvertLeadControllerTest.cls
@@ -54,7 +54,7 @@ public class ConvertLeadControllerTest {
         System.assertEquals('Open - Not Contacted', updatedLead.Lead_Stage_at_Exit__c);
 
         Opportunity opp = [SELECT StageName, Probability FROM Opportunity WHERE Id = :result.opportunityId];
-        System.assertEquals('Stage 3 - Prospect', opp.StageName);
+        System.assertEquals('Stage 4 - Proposal Development', opp.StageName);
         System.assertEquals(20, opp.Probability);
 
         Contact con = [SELECT Status__c, GSP_Primary_Contact__c, Last_Lead_Outcome__c,

--- a/src/classes/ConvertLeadControllerTest.cls
+++ b/src/classes/ConvertLeadControllerTest.cls
@@ -1,0 +1,239 @@
+@isTest
+public class ConvertLeadControllerTest {
+
+    @TestSetup
+    static void setup() {
+        insert new Business_Unit__c(Name = 'Inc');
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    static Lead makeTestLead(String company) {
+        return new Lead(
+            FirstName = 'Test',
+            LastName = 'Lead',
+            Company = company,
+            Email = 'test@example.com',
+            Status = 'Open - Not Contacted',
+            Lead_Status_Reason__c = 'Personal Outreach',
+            Opportunity_Owner_Division__c = 'CommCare',
+            Opportunity_Owner_Sub_Division__c = 'CommCare Sales'
+        );
+    }
+
+    // ── ConvertLeadController ──────────────────────────────────────────────────
+
+    @isTest
+    static void testConvertWithOpportunity() {
+        Lead testLead = makeTestLead('OpportunityTest Co');
+        insert testLead;
+
+        Test.startTest();
+        ConvertLeadController.ConvertResult result = ConvertLeadController.convertLead(
+            testLead.Id,
+            'With Opportunity',
+            'Great fit, moving forward.',
+            null,
+            null,
+            null,
+            null,
+            'OpportunityTest Co - Deal'
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.success, result.errorMessage);
+        System.assertNotEquals(null, result.opportunityId, 'Opportunity should be created');
+        System.assertNotEquals(null, result.contactId, 'Contact should be created');
+
+        Lead updatedLead = [SELECT Status, Conversion_Outcome__c, Disposition_Notes__c, Lead_Stage_at_Exit__c FROM Lead WHERE Id = :testLead.Id];
+        System.assertEquals('Converted', updatedLead.Status);
+        System.assertEquals('With Opportunity', updatedLead.Conversion_Outcome__c);
+        System.assertEquals('Great fit, moving forward.', updatedLead.Disposition_Notes__c);
+        System.assertEquals('Open - Not Contacted', updatedLead.Lead_Stage_at_Exit__c);
+
+        Opportunity opp = [SELECT StageName, Probability FROM Opportunity WHERE Id = :result.opportunityId];
+        System.assertEquals('Stage 3 - Prospect', opp.StageName);
+        System.assertEquals(20, opp.Probability);
+
+        Contact con = [SELECT Status__c, Last_Lead_Outcome__c, Last_Lead_Context__c,
+                              Last_Lead_Re_engage_Date__c, Last_Lead_Re_engagement_Pathway__c,
+                              Last_Lead_Date__c, Lead_Cycle_Count__c
+                       FROM Contact WHERE Id = :result.contactId];
+        System.assertEquals('1- Working - Active Opp Development', con.Status__c);
+        System.assertEquals('With Opportunity', con.Last_Lead_Outcome__c);
+        System.assertEquals('Great fit, moving forward.', con.Last_Lead_Context__c);
+        System.assertEquals(null, con.Last_Lead_Re_engage_Date__c);
+        System.assertEquals(null, con.Last_Lead_Re_engagement_Pathway__c);
+        System.assertEquals(Date.today(), con.Last_Lead_Date__c);
+        System.assertEquals(1, con.Lead_Cycle_Count__c);
+    }
+
+    @isTest
+    static void testConvertContactOnlyNurture() {
+        Lead testLead = makeTestLead('NurtureTest Co');
+        insert testLead;
+
+        Test.startTest();
+        ConvertLeadController.ConvertResult result = ConvertLeadController.convertLead(
+            testLead.Id,
+            'Contact Only - Passive',
+            'Good relationship, no immediate opportunity.',
+            'Scheduled Follow-up',
+            Date.today().addMonths(3),
+            null,
+            null,
+            null
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.success, result.errorMessage);
+        System.assertEquals(null, result.opportunityId, 'No opportunity should be created');
+        System.assertNotEquals(null, result.contactId, 'Contact should be created');
+
+        Lead updatedLead = [SELECT Conversion_Outcome__c, Re_engagement_Pathway__c, Re_engage_Date__c FROM Lead WHERE Id = :testLead.Id];
+        System.assertEquals('Contact Only - Passive', updatedLead.Conversion_Outcome__c);
+        System.assertEquals('Scheduled Follow-up', updatedLead.Re_engagement_Pathway__c);
+        System.assertEquals(Date.today().addMonths(3), updatedLead.Re_engage_Date__c);
+
+        Contact con = [SELECT Last_Lead_Outcome__c, Last_Lead_Context__c, Last_Lead_Re_engage_Date__c,
+                              Last_Lead_Re_engagement_Pathway__c, Last_Lead_Date__c, Lead_Cycle_Count__c
+                       FROM Contact WHERE Id = :result.contactId];
+        System.assertEquals('Contact Only - Passive', con.Last_Lead_Outcome__c);
+        System.assertEquals('Good relationship, no immediate opportunity.', con.Last_Lead_Context__c);
+        System.assertEquals(Date.today().addMonths(3), con.Last_Lead_Re_engage_Date__c);
+        System.assertEquals('Scheduled Follow-up', con.Last_Lead_Re_engagement_Pathway__c);
+        System.assertEquals(Date.today(), con.Last_Lead_Date__c);
+        System.assertEquals(1, con.Lead_Cycle_Count__c);
+    }
+
+    @isTest
+    static void testConvertWithExistingAccount() {
+        Account existingAccount = new Account(Name = 'Existing Account Corp');
+        insert existingAccount;
+        Lead testLead = makeTestLead('Existing Account Corp');
+        insert testLead;
+
+        Test.startTest();
+        ConvertLeadController.ConvertResult result = ConvertLeadController.convertLead(
+            testLead.Id,
+            'With Opportunity',
+            null,
+            null,
+            null,
+            existingAccount.Id,
+            null,
+            'Existing Account Corp - Deal'
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.success, result.errorMessage);
+        System.assertEquals(existingAccount.Id, result.accountId, 'Should use the existing account');
+        System.assertEquals(1, [SELECT COUNT() FROM Account WHERE Name = 'Existing Account Corp'], 'No duplicate account should be created');
+    }
+
+    @isTest
+    static void testConvertWithExistingContact() {
+        Account acc = new Account(Name = 'Contact Match Co');
+        insert acc;
+        Contact existingContact = new Contact(FirstName = 'Test', LastName = 'Lead', AccountId = acc.Id, Email = 'test@example.com');
+        insert existingContact;
+        Lead testLead = makeTestLead('Contact Match Co');
+        insert testLead;
+
+        Test.startTest();
+        ConvertLeadController.ConvertResult result = ConvertLeadController.convertLead(
+            testLead.Id,
+            'Contact Only - Nurture',
+            null,
+            'Passive',
+            null,
+            acc.Id,
+            existingContact.Id,
+            null
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.success, result.errorMessage);
+        System.assertEquals(existingContact.Id, result.contactId, 'Should use the existing contact');
+
+        Contact con = [SELECT Last_Lead_Outcome__c, Last_Lead_Date__c, Lead_Cycle_Count__c
+                       FROM Contact WHERE Id = :result.contactId];
+        System.assertEquals('Contact Only - Nurture', con.Last_Lead_Outcome__c);
+        System.assertEquals(Date.today(), con.Last_Lead_Date__c);
+        System.assertEquals(1, con.Lead_Cycle_Count__c);
+    }
+
+    @isTest
+    static void testSearchAccounts() {
+        insert new Account(Name = 'Searchable Corp XYZ');
+
+        Test.startTest();
+        List<Account> results = ConvertLeadController.searchAccounts('Searchable Corp');
+        Test.stopTest();
+
+        System.assertEquals(1, results.size());
+        System.assertEquals('Searchable Corp XYZ', results[0].Name);
+    }
+
+    @isTest
+    static void testSearchContacts() {
+        Account acc = new Account(Name = 'Test Acc');
+        insert acc;
+        insert new Contact(FirstName = 'Jane', LastName = 'SearchableXYZ', AccountId = acc.Id, Email = 'jane@example.com');
+
+        Test.startTest();
+        List<Contact> nameResults = ConvertLeadController.searchContacts('SearchableXYZ');
+        List<Contact> emailResults = ConvertLeadController.searchContacts('jane@example.com');
+        Test.stopTest();
+
+        System.assertEquals(1, nameResults.size());
+        System.assertEquals(1, emailResults.size());
+    }
+
+    @isTest
+    static void testGetLeadDetails() {
+        Lead testLead = makeTestLead('Detail Co');
+        insert testLead;
+
+        Test.startTest();
+        Lead result = ConvertLeadController.getLeadDetails(testLead.Id);
+        Test.stopTest();
+
+        System.assertEquals(testLead.Id, result.Id);
+        System.assertEquals('Detail Co', result.Company);
+    }
+
+    // ── ArchiveLeadController ──────────────────────────────────────────────────
+
+    @isTest
+    static void testArchiveLead() {
+        Lead testLead = makeTestLead('Archive Co');
+        testLead.Status = 'Stage 1 - Contacted';
+        testLead.Lead_Status_Reason__c = 'Personal Outreach';
+        insert testLead;
+
+        Test.startTest();
+        ArchiveLeadController.archiveLead(testLead.Id, 'No Response', 'Never responded after 5 attempts.');
+        Test.stopTest();
+
+        Lead updatedLead = [SELECT Status, Archive_Reason__c, Disposition_Notes__c, Lead_Stage_at_Exit__c FROM Lead WHERE Id = :testLead.Id];
+        System.assertEquals('Archived - Not Interested', updatedLead.Status);
+        System.assertEquals('No Response', updatedLead.Archive_Reason__c);
+        System.assertEquals('Never responded after 5 attempts.', updatedLead.Disposition_Notes__c);
+        System.assertEquals('Stage 1 - Contacted', updatedLead.Lead_Stage_at_Exit__c);
+    }
+
+    @isTest
+    static void testArchiveLeadNotAFit() {
+        Lead testLead = makeTestLead('No Fit Co');
+        insert testLead;
+
+        Test.startTest();
+        ArchiveLeadController.archiveLead(testLead.Id, 'Not a Fit', null);
+        Test.stopTest();
+
+        Lead updatedLead = [SELECT Status, Archive_Reason__c FROM Lead WHERE Id = :testLead.Id];
+        System.assertEquals('Archived - Not Interested', updatedLead.Status);
+        System.assertEquals('Not a Fit', updatedLead.Archive_Reason__c);
+    }
+}

--- a/src/classes/ConvertLeadControllerTest.cls-meta.xml
+++ b/src/classes/ConvertLeadControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/main/default/lwc/archiveLead/archiveLead.html
+++ b/src/main/default/lwc/archiveLead/archiveLead.html
@@ -1,0 +1,51 @@
+<template>
+    <lightning-card title="Archive Lead">
+        <template lwc:if={isLoading}>
+            <lightning-spinner alternative-text="Archiving..." size="small"></lightning-spinner>
+        </template>
+
+        <div class="slds-p-around_medium">
+
+            <lightning-combobox
+                name="archiveReason"
+                label="Archive Reason"
+                required
+                value={archiveReason}
+                placeholder="Select a reason"
+                options={archiveReasonOptions}
+                onchange={handleReasonChange}>
+            </lightning-combobox>
+
+            <div class="slds-m-top_small">
+                <lightning-textarea
+                    name="dispositionNotes"
+                    label="Disposition Notes"
+                    value={dispositionNotes}
+                    onchange={handleDispositionNotesChange}>
+                </lightning-textarea>
+            </div>
+
+            <template lwc:if={errorMessage}>
+                <div class="slds-notify slds-notify_alert slds-alert_error slds-m-top_small" role="alert">
+                    <span class="slds-assistive-text">Error</span>
+                    {errorMessage}
+                </div>
+            </template>
+
+        </div>
+
+        <div slot="footer">
+            <lightning-button
+                label="Cancel"
+                onclick={handleCancel}>
+            </lightning-button>
+            <lightning-button
+                variant="destructive"
+                label="Archive"
+                onclick={handleArchive}
+                disabled={isLoading}
+                class="slds-m-left_x-small">
+            </lightning-button>
+        </div>
+    </lightning-card>
+</template>

--- a/src/main/default/lwc/archiveLead/archiveLead.js
+++ b/src/main/default/lwc/archiveLead/archiveLead.js
@@ -1,0 +1,65 @@
+import { LightningElement, api } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import { CloseActionScreenEvent } from 'lightning/actions';
+import { RefreshEvent } from 'lightning/refresh';
+import archiveLead from '@salesforce/apex/ArchiveLeadController.archiveLead';
+
+const ARCHIVE_REASON_OPTIONS = [
+    { label: 'No Response', value: 'No Response' },
+    { label: 'Not a Fit', value: 'Not a Fit' },
+    { label: 'Other', value: 'Other' },
+];
+
+export default class ArchiveLead extends LightningElement {
+    @api recordId;
+
+    archiveReason = '';
+    dispositionNotes = '';
+    isLoading = false;
+    errorMessage = '';
+
+    archiveReasonOptions = ARCHIVE_REASON_OPTIONS;
+
+    handleReasonChange(event) {
+        this.archiveReason = event.detail.value;
+    }
+
+    handleDispositionNotesChange(event) {
+        this.dispositionNotes = event.detail.value;
+    }
+
+    handleArchive() {
+        this.errorMessage = '';
+
+        if (!this.archiveReason) {
+            this.errorMessage = 'Archive Reason is required.';
+            return;
+        }
+
+        this.isLoading = true;
+
+        archiveLead({
+            leadId: this.recordId,
+            archiveReason: this.archiveReason,
+            dispositionNotes: this.dispositionNotes || null,
+        })
+        .then(() => {
+            this.isLoading = false;
+            this.dispatchEvent(new ShowToastEvent({
+                title: 'Lead archived',
+                message: 'The lead was archived successfully.',
+                variant: 'success',
+            }));
+            this.dispatchEvent(new CloseActionScreenEvent());
+            this.dispatchEvent(new RefreshEvent());
+        })
+        .catch(error => {
+            this.isLoading = false;
+            this.errorMessage = (error.body && error.body.message) ? error.body.message : 'An unexpected error occurred.';
+        });
+    }
+
+    handleCancel() {
+        this.dispatchEvent(new CloseActionScreenEvent());
+    }
+}

--- a/src/main/default/lwc/archiveLead/archiveLead.js-meta.xml
+++ b/src/main/default/lwc/archiveLead/archiveLead.js-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordAction</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordAction">
+            <actionType>Action</actionType>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/src/main/default/lwc/convertLead/convertLead.html
+++ b/src/main/default/lwc/convertLead/convertLead.html
@@ -53,8 +53,7 @@
                                 <lightning-input
                                     type="date"
                                     name="reEngageDate"
-                                    label="Re-engage Date"
-                                    required
+                                    label="Contact Follow-up Date"
                                     value={reEngageDate}
                                     onchange={handleReEngageDateChange}>
                                 </lightning-input>
@@ -166,7 +165,9 @@
                                                 class="slds-listbox__item"
                                                 onclick={selectContact}
                                                 data-id={con.Id}
-                                                data-name={con.Name}>
+                                                data-name={con.Name}
+                                                data-status={con.Status__c}
+                                                data-gsp={con.GSP_Primary_Contact__c}>
                                                 <span class="slds-media slds-listbox__option slds-listbox__option_plain" role="option">
                                                     <span class="slds-media__figure">
                                                         <lightning-icon icon-name="standard:contact" size="x-small"></lightning-icon>
@@ -185,6 +186,27 @@
                                 Leave blank to create a new contact from this lead.
                             </p>
                         </template>
+                    </div>
+                </div>
+
+                <!-- Contact Status + GSP Primary Contact -->
+                <div class="slds-box slds-m-top_small slds-p-around_small">
+                    <lightning-combobox
+                        name="contactStatus"
+                        label="Contact Status"
+                        value={contactStatus}
+                        placeholder="Select a status"
+                        options={contactStatusOptions}
+                        onchange={handleContactStatusChange}>
+                    </lightning-combobox>
+                    <div class="slds-m-top_small">
+                        <lightning-input
+                            type="checkbox"
+                            name="gspPrimaryContact"
+                            label="GSP Primary Contact"
+                            checked={gspPrimaryContact}
+                            onchange={handleGspPrimaryContactChange}>
+                        </lightning-input>
                     </div>
                 </div>
 

--- a/src/main/default/lwc/convertLead/convertLead.html
+++ b/src/main/default/lwc/convertLead/convertLead.html
@@ -1,0 +1,217 @@
+<template>
+    <lightning-card title="Convert Lead">
+        <div class="slds-p-around_medium">
+
+            <template lwc:if={isInitializing}>
+                <div class="slds-align_absolute-center slds-p-around_large">
+                    <lightning-spinner alternative-text="Loading..." size="small"></lightning-spinner>
+                </div>
+            </template>
+
+            <template lwc:else>
+
+                <template lwc:if={isLoading}>
+                    <lightning-spinner alternative-text="Converting..." size="small"></lightning-spinner>
+                </template>
+
+                <!-- Conversion Outcome -->
+                <lightning-combobox
+                    name="conversionOutcome"
+                    label="Conversion Outcome"
+                    required
+                    value={conversionOutcome}
+                    placeholder="Select an outcome"
+                    options={conversionOutcomeOptions}
+                    onchange={handleOutcomeChange}>
+                </lightning-combobox>
+
+                <!-- Disposition Notes -->
+                <div class="slds-m-top_small">
+                    <lightning-textarea
+                        name="dispositionNotes"
+                        label="Disposition Notes"
+                        value={dispositionNotes}
+                        onchange={handleDispositionNotesChange}>
+                    </lightning-textarea>
+                </div>
+
+                <!-- Contact Only section -->
+                <template lwc:if={isContactOnly}>
+                    <div class="slds-box slds-m-top_small slds-p-around_small">
+                        <p class="slds-text-title_caps slds-m-bottom_x-small">Re-engagement Plan</p>
+                        <lightning-combobox
+                            name="reEngagementPathway"
+                            label="Re-engagement Pathway"
+                            required
+                            value={reEngagementPathway}
+                            placeholder="Select a pathway"
+                            options={pathwayOptions}
+                            onchange={handlePathwayChange}>
+                        </lightning-combobox>
+                        <template lwc:if={showReEngageDate}>
+                            <div class="slds-m-top_small">
+                                <lightning-input
+                                    type="date"
+                                    name="reEngageDate"
+                                    label="Re-engage Date"
+                                    required
+                                    value={reEngageDate}
+                                    onchange={handleReEngageDateChange}>
+                                </lightning-input>
+                            </div>
+                        </template>
+                    </div>
+                </template>
+
+                <!-- With Opportunity section -->
+                <template lwc:if={isWithOpportunity}>
+                    <div class="slds-box slds-m-top_small slds-p-around_small">
+                        <lightning-input
+                            type="text"
+                            name="opportunityName"
+                            label="Opportunity Name"
+                            required
+                            value={opportunityName}
+                            onchange={handleOppNameChange}>
+                        </lightning-input>
+                    </div>
+                </template>
+
+                <!-- Account lookup -->
+                <div class="slds-form-element slds-m-top_small">
+                    <label class="slds-form-element__label">Account</label>
+                    <div class="slds-form-element__control slds-m-top_xx-small">
+                        <template lwc:if={selectedAccountId}>
+                            <div class="slds-pill_container">
+                                <span class="slds-pill">
+                                    <span class="slds-pill__label">{selectedAccountName}</span>
+                                    <button
+                                        class="slds-button slds-button_icon slds-pill__remove"
+                                        onclick={clearAccount}
+                                        title="Remove">
+                                        <lightning-icon icon-name="utility:close" size="x-small"></lightning-icon>
+                                    </button>
+                                </span>
+                            </div>
+                        </template>
+                        <template lwc:else>
+                            <lightning-input
+                                type="search"
+                                label="Search existing accounts"
+                                variant="label-hidden"
+                                placeholder="Type to search accounts..."
+                                value={accountSearchTerm}
+                                onchange={handleAccountSearch}>
+                            </lightning-input>
+                            <template lwc:if={hasAccountResults}>
+                                <div class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid" role="listbox">
+                                    <ul class="slds-listbox slds-listbox_vertical" role="presentation">
+                                        <template for:each={accountResults} for:item="acc">
+                                            <li key={acc.Id}
+                                                role="presentation"
+                                                class="slds-listbox__item"
+                                                onclick={selectAccount}
+                                                data-id={acc.Id}
+                                                data-name={acc.Name}>
+                                                <span class="slds-media slds-listbox__option slds-listbox__option_plain" role="option">
+                                                    <span class="slds-media__figure">
+                                                        <lightning-icon icon-name="standard:account" size="x-small"></lightning-icon>
+                                                    </span>
+                                                    <span class="slds-media__body">{acc.Name}</span>
+                                                </span>
+                                            </li>
+                                        </template>
+                                    </ul>
+                                </div>
+                            </template>
+                            <p class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                Leave blank to create a new account for: {leadCompany}
+                            </p>
+                        </template>
+                    </div>
+                </div>
+
+                <!-- Contact lookup -->
+                <div class="slds-form-element slds-m-top_small">
+                    <label class="slds-form-element__label">Contact</label>
+                    <div class="slds-form-element__control slds-m-top_xx-small">
+                        <template lwc:if={selectedContactId}>
+                            <div class="slds-pill_container">
+                                <span class="slds-pill">
+                                    <span class="slds-pill__label">{selectedContactName}</span>
+                                    <button
+                                        class="slds-button slds-button_icon slds-pill__remove"
+                                        onclick={clearContact}
+                                        title="Remove">
+                                        <lightning-icon icon-name="utility:close" size="x-small"></lightning-icon>
+                                    </button>
+                                </span>
+                            </div>
+                        </template>
+                        <template lwc:else>
+                            <lightning-input
+                                type="search"
+                                label="Search existing contacts"
+                                variant="label-hidden"
+                                placeholder="Type to search by name or email..."
+                                value={contactSearchTerm}
+                                onchange={handleContactSearch}>
+                            </lightning-input>
+                            <template lwc:if={hasContactResults}>
+                                <div class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid" role="listbox">
+                                    <ul class="slds-listbox slds-listbox_vertical" role="presentation">
+                                        <template for:each={contactResults} for:item="con">
+                                            <li key={con.Id}
+                                                role="presentation"
+                                                class="slds-listbox__item"
+                                                onclick={selectContact}
+                                                data-id={con.Id}
+                                                data-name={con.Name}>
+                                                <span class="slds-media slds-listbox__option slds-listbox__option_plain" role="option">
+                                                    <span class="slds-media__figure">
+                                                        <lightning-icon icon-name="standard:contact" size="x-small"></lightning-icon>
+                                                    </span>
+                                                    <span class="slds-media__body">
+                                                        {con.Name}
+                                                        <span class="slds-text-color_weak"> &mdash; {con.Email}</span>
+                                                    </span>
+                                                </span>
+                                            </li>
+                                        </template>
+                                    </ul>
+                                </div>
+                            </template>
+                            <p class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                Leave blank to create a new contact from this lead.
+                            </p>
+                        </template>
+                    </div>
+                </div>
+
+                <!-- Error message -->
+                <template lwc:if={errorMessage}>
+                    <div class="slds-notify slds-notify_alert slds-alert_error slds-m-top_small" role="alert">
+                        <span class="slds-assistive-text">Error</span>
+                        {errorMessage}
+                    </div>
+                </template>
+
+            </template>
+
+        </div>
+
+        <div slot="footer">
+            <lightning-button
+                label="Cancel"
+                onclick={handleCancel}>
+            </lightning-button>
+            <lightning-button
+                variant="brand"
+                label="Convert"
+                onclick={handleConvert}
+                disabled={isLoading}
+                class="slds-m-left_x-small">
+            </lightning-button>
+        </div>
+    </lightning-card>
+</template>

--- a/src/main/default/lwc/convertLead/convertLead.js
+++ b/src/main/default/lwc/convertLead/convertLead.js
@@ -1,0 +1,256 @@
+import { LightningElement, api } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import { CloseActionScreenEvent } from 'lightning/actions';
+import convertLead from '@salesforce/apex/ConvertLeadController.convertLead';
+import searchAccounts from '@salesforce/apex/ConvertLeadController.searchAccounts';
+import searchContacts from '@salesforce/apex/ConvertLeadController.searchContacts';
+import getLeadDetails from '@salesforce/apex/ConvertLeadController.getLeadDetails';
+import getSuggestedMatches from '@salesforce/apex/ConvertLeadController.getSuggestedMatches';
+
+const SEARCH_DELAY = 300;
+
+const CONVERSION_OUTCOME_OPTIONS = [
+    { label: 'With Opportunity', value: 'With Opportunity' },
+    { label: 'Contact Only - Nurture', value: 'Contact Only - Nurture' },
+    { label: 'Contact Only - Passive', value: 'Contact Only - Passive' },
+];
+
+const PATHWAY_OPTIONS = [
+    { label: 'Scheduled Follow-up', value: 'Scheduled Follow-up' },
+    { label: 'Passive', value: 'Passive' },
+];
+
+export default class ConvertLead extends NavigationMixin(LightningElement) {
+    _recordId;
+    _initialized = false;
+
+    @api
+    get recordId() { return this._recordId; }
+    set recordId(val) {
+        this._recordId = val;
+        if (val) this._initOnce();
+    }
+
+    conversionOutcome = '';
+    dispositionNotes = '';
+    reEngagementPathway = '';
+    reEngageDate = null;
+    opportunityName = '';
+    leadCompany = '';
+
+    accountSearchTerm = '';
+    accountResults = [];
+    selectedAccountId = null;
+    selectedAccountName = '';
+
+    contactSearchTerm = '';
+    contactResults = [];
+    selectedContactId = null;
+    selectedContactName = '';
+
+    isLoading = false;
+    isInitializing = true;
+    errorMessage = '';
+
+    _accountSearchTimeout;
+    _contactSearchTimeout;
+
+    conversionOutcomeOptions = CONVERSION_OUTCOME_OPTIONS;
+    pathwayOptions = PATHWAY_OPTIONS;
+
+    connectedCallback() {
+        if (this._recordId) this._initOnce();
+    }
+
+    _initOnce() {
+        if (this._initialized) return;
+        this._initialized = true;
+        Promise.allSettled([
+            getLeadDetails({ leadId: this._recordId }),
+            getSuggestedMatches({ leadId: this._recordId }),
+        ]).then(([leadResult, matchesResult]) => {
+            if (leadResult.status === 'fulfilled' && leadResult.value) {
+                this.leadCompany = leadResult.value.Company || '';
+                this.opportunityName = leadResult.value.Company || '';
+            }
+            if (matchesResult.status === 'fulfilled' && matchesResult.value) {
+                const m = matchesResult.value;
+                if (m.accountId) {
+                    this.selectedAccountId = m.accountId;
+                    this.selectedAccountName = m.accountName;
+                }
+                if (m.contactId) {
+                    this.selectedContactId = m.contactId;
+                    this.selectedContactName = m.contactName;
+                }
+            } else if (matchesResult.status === 'rejected') {
+                this.errorMessage = matchesResult.reason?.body?.message || String(matchesResult.reason);
+            }
+            this.isInitializing = false;
+        });
+    }
+
+    get isContactOnly() {
+        return this.conversionOutcome === 'Contact Only - Nurture' ||
+               this.conversionOutcome === 'Contact Only - Passive';
+    }
+
+    get isWithOpportunity() {
+        return this.conversionOutcome === 'With Opportunity';
+    }
+
+    get showReEngageDate() {
+        return this.reEngagementPathway === 'Scheduled Follow-up';
+    }
+
+    get hasAccountResults() {
+        return this.accountResults.length > 0;
+    }
+
+    get hasContactResults() {
+        return this.contactResults.length > 0;
+    }
+
+    handleOutcomeChange(event) {
+        this.conversionOutcome = event.detail.value;
+        this.reEngagementPathway = '';
+        this.reEngageDate = null;
+    }
+
+    handleDispositionNotesChange(event) {
+        this.dispositionNotes = event.detail.value;
+    }
+
+    handlePathwayChange(event) {
+        this.reEngagementPathway = event.detail.value;
+        if (this.reEngagementPathway !== 'Scheduled Follow-up') {
+            this.reEngageDate = null;
+        }
+    }
+
+    handleReEngageDateChange(event) {
+        this.reEngageDate = event.detail.value || null;
+    }
+
+    handleOppNameChange(event) {
+        this.opportunityName = event.detail.value;
+    }
+
+    handleAccountSearch(event) {
+        const term = event.detail.value;
+        this.accountSearchTerm = term;
+        clearTimeout(this._accountSearchTimeout);
+        if (!term || term.length < 2) {
+            this.accountResults = [];
+            return;
+        }
+        this._accountSearchTimeout = setTimeout(() => {
+            searchAccounts({ searchTerm: term })
+                .then(results => { this.accountResults = results; })
+                .catch(() => { this.accountResults = []; });
+        }, SEARCH_DELAY);
+    }
+
+    selectAccount(event) {
+        this.selectedAccountId = event.currentTarget.dataset.id;
+        this.selectedAccountName = event.currentTarget.dataset.name;
+        this.accountResults = [];
+        this.accountSearchTerm = '';
+    }
+
+    clearAccount() {
+        this.selectedAccountId = null;
+        this.selectedAccountName = '';
+    }
+
+    handleContactSearch(event) {
+        const term = event.detail.value;
+        this.contactSearchTerm = term;
+        clearTimeout(this._contactSearchTimeout);
+        if (!term || term.length < 2) {
+            this.contactResults = [];
+            return;
+        }
+        this._contactSearchTimeout = setTimeout(() => {
+            searchContacts({ searchTerm: term })
+                .then(results => { this.contactResults = results; })
+                .catch(() => { this.contactResults = []; });
+        }, SEARCH_DELAY);
+    }
+
+    selectContact(event) {
+        this.selectedContactId = event.currentTarget.dataset.id;
+        this.selectedContactName = event.currentTarget.dataset.name;
+        this.contactResults = [];
+        this.contactSearchTerm = '';
+    }
+
+    clearContact() {
+        this.selectedContactId = null;
+        this.selectedContactName = '';
+    }
+
+    handleConvert() {
+        this.errorMessage = '';
+
+        if (!this.conversionOutcome) {
+            this.errorMessage = 'Conversion Outcome is required.';
+            return;
+        }
+        if (this.isContactOnly && !this.reEngagementPathway) {
+            this.errorMessage = 'Re-engagement Pathway is required for Contact Only conversions.';
+            return;
+        }
+        if (this.isContactOnly && this.reEngagementPathway === 'Scheduled Follow-up' && !this.reEngageDate) {
+            this.errorMessage = 'Re-engage Date is required when pathway is Scheduled Follow-up.';
+            return;
+        }
+        if (this.isWithOpportunity && !this.opportunityName) {
+            this.errorMessage = 'Opportunity Name is required.';
+            return;
+        }
+
+        this.isLoading = true;
+
+        convertLead({
+            leadId: this._recordId,
+            conversionOutcome: this.conversionOutcome,
+            dispositionNotes: this.dispositionNotes || null,
+            reEngagementPathway: this.isContactOnly ? this.reEngagementPathway : null,
+            reEngageDate: (this.isContactOnly && this.reEngageDate) ? this.reEngageDate : null,
+            existingAccountId: this.selectedAccountId || null,
+            existingContactId: this.selectedContactId || null,
+            opportunityName: this.isWithOpportunity ? this.opportunityName : null,
+        })
+        .then(result => {
+            this.isLoading = false;
+            if (result.success) {
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Lead converted',
+                    message: 'The lead was converted successfully.',
+                    variant: 'success',
+                }));
+                this.dispatchEvent(new CloseActionScreenEvent());
+                const navId = result.opportunityId || result.contactId;
+                const objectApiName = result.opportunityId ? 'Opportunity' : 'Contact';
+                if (navId) {
+                    this[NavigationMixin.Navigate]({
+                        type: 'standard__recordPage',
+                        attributes: { recordId: navId, objectApiName, actionName: 'view' },
+                    });
+                }
+            } else {
+                this.errorMessage = result.errorMessage || 'An unexpected error occurred.';
+            }
+        })
+        .catch(error => {
+            this.isLoading = false;
+            this.errorMessage = (error.body && error.body.message) ? error.body.message : 'An unexpected error occurred.';
+        });
+    }
+
+    handleCancel() {
+        this.dispatchEvent(new CloseActionScreenEvent());
+    }
+}

--- a/src/main/default/lwc/convertLead/convertLead.js
+++ b/src/main/default/lwc/convertLead/convertLead.js
@@ -1,7 +1,10 @@
-import { LightningElement, api } from 'lwc';
+import { LightningElement, api, wire } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { CloseActionScreenEvent } from 'lightning/actions';
+import { getPicklistValues, getObjectInfo } from 'lightning/uiObjectInfoApi';
+import CONTACT_OBJECT from '@salesforce/schema/Contact';
+import STATUS_FIELD from '@salesforce/schema/Contact.Status__c';
 import convertLead from '@salesforce/apex/ConvertLeadController.convertLead';
 import searchAccounts from '@salesforce/apex/ConvertLeadController.searchAccounts';
 import searchContacts from '@salesforce/apex/ConvertLeadController.searchContacts';
@@ -9,6 +12,7 @@ import getLeadDetails from '@salesforce/apex/ConvertLeadController.getLeadDetail
 import getSuggestedMatches from '@salesforce/apex/ConvertLeadController.getSuggestedMatches';
 
 const SEARCH_DELAY = 300;
+const DEFAULT_CONTACT_STATUS = '1- Working - Active Opp Development';
 
 const CONVERSION_OUTCOME_OPTIONS = [
     { label: 'With Opportunity', value: 'With Opportunity' },
@@ -34,7 +38,7 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
 
     conversionOutcome = '';
     dispositionNotes = '';
-    reEngagementPathway = '';
+    reEngagementPathway = 'Passive';
     reEngageDate = null;
     opportunityName = '';
     leadCompany = '';
@@ -49,6 +53,9 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
     selectedContactId = null;
     selectedContactName = '';
 
+    contactStatus = DEFAULT_CONTACT_STATUS;
+    gspPrimaryContact = false;
+
     isLoading = false;
     isInitializing = true;
     errorMessage = '';
@@ -58,6 +65,16 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
 
     conversionOutcomeOptions = CONVERSION_OUTCOME_OPTIONS;
     pathwayOptions = PATHWAY_OPTIONS;
+
+    @wire(getObjectInfo, { objectApiName: CONTACT_OBJECT })
+    _contactObjectInfo;
+
+    @wire(getPicklistValues, { recordTypeId: '$_contactObjectInfo.data.defaultRecordTypeId', fieldApiName: STATUS_FIELD })
+    _contactStatusPicklist;
+
+    get contactStatusOptions() {
+        return this._contactStatusPicklist.data?.values || [];
+    }
 
     connectedCallback() {
         if (this._recordId) this._initOnce();
@@ -83,6 +100,9 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
                 if (m.contactId) {
                     this.selectedContactId = m.contactId;
                     this.selectedContactName = m.contactName;
+                    this.reEngageDate = m.contactFollowUpDate || null;
+                    this.contactStatus = m.contactStatus || DEFAULT_CONTACT_STATUS;
+                    this.gspPrimaryContact = m.contactGspPrimaryContact || false;
                 }
             } else if (matchesResult.status === 'rejected') {
                 this.errorMessage = matchesResult.reason?.body?.message || String(matchesResult.reason);
@@ -114,7 +134,7 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
 
     handleOutcomeChange(event) {
         this.conversionOutcome = event.detail.value;
-        this.reEngagementPathway = '';
+        this.reEngagementPathway = 'Passive';
         this.reEngageDate = null;
     }
 
@@ -135,6 +155,14 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
 
     handleOppNameChange(event) {
         this.opportunityName = event.detail.value;
+    }
+
+    handleContactStatusChange(event) {
+        this.contactStatus = event.detail.value;
+    }
+
+    handleGspPrimaryContactChange(event) {
+        this.gspPrimaryContact = event.detail.checked;
     }
 
     handleAccountSearch(event) {
@@ -180,8 +208,11 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
     }
 
     selectContact(event) {
-        this.selectedContactId = event.currentTarget.dataset.id;
-        this.selectedContactName = event.currentTarget.dataset.name;
+        const el = event.currentTarget;
+        this.selectedContactId = el.dataset.id;
+        this.selectedContactName = el.dataset.name;
+        this.contactStatus = el.dataset.status || DEFAULT_CONTACT_STATUS;
+        this.gspPrimaryContact = el.dataset.gsp === 'true';
         this.contactResults = [];
         this.contactSearchTerm = '';
     }
@@ -189,6 +220,8 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
     clearContact() {
         this.selectedContactId = null;
         this.selectedContactName = '';
+        this.contactStatus = DEFAULT_CONTACT_STATUS;
+        this.gspPrimaryContact = false;
     }
 
     handleConvert() {
@@ -200,10 +233,6 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
         }
         if (this.isContactOnly && !this.reEngagementPathway) {
             this.errorMessage = 'Re-engagement Pathway is required for Contact Only conversions.';
-            return;
-        }
-        if (this.isContactOnly && this.reEngagementPathway === 'Scheduled Follow-up' && !this.reEngageDate) {
-            this.errorMessage = 'Re-engage Date is required when pathway is Scheduled Follow-up.';
             return;
         }
         if (this.isWithOpportunity && !this.opportunityName) {
@@ -222,6 +251,8 @@ export default class ConvertLead extends NavigationMixin(LightningElement) {
             existingAccountId: this.selectedAccountId || null,
             existingContactId: this.selectedContactId || null,
             opportunityName: this.isWithOpportunity ? this.opportunityName : null,
+            contactStatus: this.contactStatus || DEFAULT_CONTACT_STATUS,
+            gspPrimaryContact: this.gspPrimaryContact,
         })
         .then(result => {
             this.isLoading = false;

--- a/src/main/default/lwc/convertLead/convertLead.js-meta.xml
+++ b/src/main/default/lwc/convertLead/convertLead.js-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordAction</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordAction">
+            <actionType>ScreenAction</actionType>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/src/main/default/objects/Contact/fields/Last_Lead_Context__c.field-meta.xml
+++ b/src/main/default/objects/Contact/fields/Last_Lead_Context__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Lead_Context__c</fullName>
+    <description>Carried over from the lead's Disposition Notes. Captures why the lead exited and any re-engagement plan. Updated by the Contact Updater flow.</description>
+    <label>Last Lead Context</label>
+    <length>2000</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>LongTextArea</type>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/src/main/default/objects/Contact/fields/Last_Lead_Date__c.field-meta.xml
+++ b/src/main/default/objects/Contact/fields/Last_Lead_Date__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Lead_Date__c</fullName>
+    <description>Date the most recent lead cycle ended (archived or converted). Updated by the Contact Updater flow.</description>
+    <label>Last Lead Date</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Date</type>
+</CustomField>

--- a/src/main/default/objects/Contact/fields/Last_Lead_Outcome__c.field-meta.xml
+++ b/src/main/default/objects/Contact/fields/Last_Lead_Outcome__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Lead_Outcome__c</fullName>
+    <description>The Conversion Outcome or archive summary from the most recent lead cycle targeting this contact. Updated by the Contact Updater flow.</description>
+    <label>Last Lead Outcome</label>
+    <length>255</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/src/main/default/objects/Contact/fields/Last_Lead_Re_engage_Date__c.field-meta.xml
+++ b/src/main/default/objects/Contact/fields/Last_Lead_Re_engage_Date__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Lead_Re_engage_Date__c</fullName>
+    <description>Carried over from the lead's Re-engage Date. Used in contact follow-up reports and list views. Updated by the Contact Updater flow.</description>
+    <label>Last Lead Re-engage Date</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Date</type>
+</CustomField>

--- a/src/main/default/objects/Contact/fields/Last_Lead_Re_engagement_Pathway__c.field-meta.xml
+++ b/src/main/default/objects/Contact/fields/Last_Lead_Re_engagement_Pathway__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Lead_Re_engagement_Pathway__c</fullName>
+    <description>Copied from the lead's Re-engagement Pathway. Tells the rep how to re-engage (e.g., Scheduled Follow-up, Event-Based). Updated by the Contact Updater flow.</description>
+    <label>Last Lead Re-engagement Pathway</label>
+    <length>255</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/src/main/default/objects/Contact/fields/Lead_Cycle_Count__c.field-meta.xml
+++ b/src/main/default/objects/Contact/fields/Lead_Cycle_Count__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Lead_Cycle_Count__c</fullName>
+    <description>Number of times this contact has been targeted as a lead. Incremented by the Contact Updater flow on each archive or conversion.</description>
+    <label>Lead Cycle Count</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/src/main/default/objects/Lead/fields/Archive_Reason__c.field-meta.xml
+++ b/src/main/default/objects/Lead/fields/Archive_Reason__c.field-meta.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Archive_Reason__c</fullName>
+    <inlineHelpText>Indicates why a lead was archived</inlineHelpText>
+    <label>Archive Reason</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>No Response</fullName>
+                <default>false</default>
+                <label>No Response</label>
+            </value>
+            <value>
+                <fullName>Not a Fit</fullName>
+                <default>false</default>
+                <label>Not a Fit</label>
+            </value>
+            <value>
+                <fullName>Other</fullName>
+                <default>false</default>
+                <label>Other</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/src/main/default/objects/Lead/fields/Conversion_Outcome__c.field-meta.xml
+++ b/src/main/default/objects/Lead/fields/Conversion_Outcome__c.field-meta.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Conversion_Outcome__c</fullName>
+    <inlineHelpText>Tracks conversion outcome</inlineHelpText>
+    <label>Conversion Outcome</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>With Opportunity</fullName>
+                <default>false</default>
+                <label>With Opportunity</label>
+            </value>
+            <value>
+                <fullName>Contact Only - Nurture</fullName>
+                <default>false</default>
+                <label>Contact Only - Nurture</label>
+            </value>
+            <value>
+                <fullName>Contact Only - Passive</fullName>
+                <default>false</default>
+                <label>Contact Only - Passive</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/src/main/default/objects/Lead/fields/Disposition_Notes__c.field-meta.xml
+++ b/src/main/default/objects/Lead/fields/Disposition_Notes__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Disposition_Notes__c</fullName>
+    <inlineHelpText>Context on this prior lead.</inlineHelpText>
+    <label>Disposition Notes</label>
+    <length>2000</length>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>LongTextArea</type>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/src/main/default/objects/Lead/fields/Lead_Stage_at_Exit__c.field-meta.xml
+++ b/src/main/default/objects/Lead/fields/Lead_Stage_at_Exit__c.field-meta.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Lead_Stage_at_Exit__c</fullName>
+    <description>Auto-populated by flow from Prior_Lead_Status__c</description>
+    <inlineHelpText>Auto-populated by flow from Prior_Lead_Status__c</inlineHelpText>
+    <label>Lead Stage at Exit</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Open - Not Contacted</fullName>
+                <default>false</default>
+                <label>Open - Not Contacted</label>
+            </value>
+            <value>
+                <fullName>Stage 1 - Contacted</fullName>
+                <default>false</default>
+                <label>Stage 1 - Contacted</label>
+            </value>
+            <value>
+                <fullName>Stage 2 - Scheduled</fullName>
+                <default>false</default>
+                <label>Stage 2 - Scheduled</label>
+            </value>
+            <value>
+                <fullName>Stage 3 - Deal Shaping</fullName>
+                <default>false</default>
+                <label>Stage 3 - Deal Shaping</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/src/main/default/objects/Lead/fields/Prior_Lead_Status__c.field-meta.xml
+++ b/src/main/default/objects/Lead/fields/Prior_Lead_Status__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Prior_Lead_Status__c</fullName>
+    <description>Helper field. Never edited by reps — flow updates it automatically on every status change. Can be hidden from page layout.</description>
+    <inlineHelpText>Helper field for tracking lead movement/status</inlineHelpText>
+    <label>Prior Lead Status</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>TextArea</type>
+</CustomField>

--- a/src/main/default/objects/Lead/fields/Re_engage_Date__c.field-meta.xml
+++ b/src/main/default/objects/Lead/fields/Re_engage_Date__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Re_engage_Date__c</fullName>
+    <inlineHelpText>Target follow-up date. Only for contact-only conversions.</inlineHelpText>
+    <label>Re-engage Date</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Date</type>
+</CustomField>

--- a/src/main/default/objects/Lead/fields/Re_engagement_Pathway__c.field-meta.xml
+++ b/src/main/default/objects/Lead/fields/Re_engagement_Pathway__c.field-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Re_engagement_Pathway__c</fullName>
+    <inlineHelpText>Next step for contact-only conversions</inlineHelpText>
+    <label>Re-engagement Pathway</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Scheduled Follow-up</fullName>
+                <default>false</default>
+                <label>Scheduled Follow-up</label>
+            </value>
+            <value>
+                <fullName>Passive</fullName>
+                <default>false</default>
+                <label>Passive</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/src/main/default/objects/Lead/validationRules/Require_Archive_Reason.validationRule-meta.xml
+++ b/src/main/default/objects/Lead/validationRules/Require_Archive_Reason.validationRule-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Require_Archive_Reason</fullName>
+    <active>true</active>
+    <description>Prevents reps from archiving by directly changing the Lead Status picklist. The Archive Lead button sets Archive_Reason__c in the same operation, so it is not blocked.</description>
+    <errorConditionFormula>AND(
+    ISPICKVAL(Status, "Archived - Not Interested"),
+    ISBLANK(TEXT(Archive_Reason__c))
+)</errorConditionFormula>
+    <errorDisplayField>Status</errorDisplayField>
+    <errorMessage>Please use the "Archive Lead" button to archive this lead.</errorMessage>
+</ValidationRule>

--- a/src/main/default/objects/Opportunity/fields/Source_Lead__c.field-meta.xml
+++ b/src/main/default/objects/Opportunity/fields/Source_Lead__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Source_Lead__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <label>Source Lead</label>
+    <referenceTo>Lead</referenceTo>
+    <relationshipLabel>Opportunities</relationshipLabel>
+    <relationshipName>Opportunities</relationshipName>
+    <required>false</required>
+    <type>Lookup</type>
+</CustomField>


### PR DESCRIPTION
## Summary

- Replaces the legacy lead conversion flow with a guided Convert Lead LWC quick action that captures conversion outcome, disposition notes, re-engagement pathway, and contact/account selection with pre-population from existing matches
- Adds Archive Lead LWC stub backed by ArchiveLeadController for a future screen flow archive action
- Adds new Lead, Contact, and Opportunity fields to support outcome-based KPI reporting
- Wires conversion context back to the Contact and Opportunity on every conversion

## New Fields

**Lead:** Conversion_Outcome__c, Archive_Reason__c, Disposition_Notes__c, Lead_Stage_at_Exit__c, Re_engagement_Pathway__c, Re_engage_Date__c, Prior_Lead_Status__c

**Contact:** Last_Lead_Outcome__c, Last_Lead_Context__c, Last_Lead_Re_engage_Date__c, Last_Lead_Re_engagement_Pathway__c, Last_Lead_Date__c, Lead_Cycle_Count__c

**Opportunity:** Source_Lead__c (Lookup to Lead)

## Conversion Behavior

- Pre-populates Account (from account_name__c lookup or Company name match) and Contact (from email match) on modal open
- Contact Status and GSP Primary Contact pre-populate from matched contact and are applied on conversion
- Re-engagement Pathway defaults to Passive; Contact Follow-up Date pre-populates from existing contact value
- Opportunity defaults: Stage 4 - Proposal Development, Execution Owner Division/Sub-Division mirrored from Lead, Expected_Buffer__c = 0, Source_Lead__c populated
- Contact.Lead__c set on first conversion only (preserves original source lead across multiple conversions)
- Lead context fields written before Database.convertLead() so data is preserved on retry if conversion fails

## Post-Deploy Manual Steps (prod)

1. Override Lead Convert button to convertLead LWC quick action
2. Add archiveLead as a quick action on the Lead page layout
3. Add new Lead, Contact, and Opportunity fields to respective page layouts
4. Set field-level security for new fields

## Test Plan

- [ ] ConvertLeadControllerTest — 10 tests, all passing in QA sandbox
- [ ] Manual: convert a lead with existing account/contact match and verify pre-population
- [ ] Manual: convert with opportunity — verify Stage 4, Execution Owner fields, Source Lead populated
- [ ] Manual: convert contact-only — verify re-engagement fields written to Contact and Lead
- [ ] Manual: verify Contact.Lead__c not overwritten on second conversion of same contact
